### PR TITLE
Add missing search paths for #include

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,6 +12,10 @@
 	"targetPath": "build",
 	"sourcePaths": ["source/fluid"],
 	"stringImportPaths": ["external"],
+	"dflags": [
+		"-P-Iexternal/tree-sitter/lib/include",
+		"-P-Iexternal/tree-sitter/lib/src"
+	],
 	"lflags-linux": [
 		"-rpath=$$ORIGIN",
 		"-Lbuild"


### PR DESCRIPTION
Otherwise, I get error messages like:

    fatal error: tree_sitter/api.h: No such file or directory
    4 | #include "tree_sitter/api.h"
